### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ $transaction = [
     ],
     'Payment' => [
         'TotalAmount' => 1000,
-    ]
+    ],
+    'TransactionType' => \Eway\Rapid\Enum\TransactionType::PURCHASE,
 ];
 
 $response = $client->createTransaction(\Eway\Rapid\Enum\ApiMethod::DIRECT, $transaction);


### PR DESCRIPTION
Seems like specifying the TransactionType is required for a basic request. Without this edit the docs here dont match with the docs provided at https://eway.io/api-v3/?php#direct-connection