### PR TITLE
[Issue #3] Adds new attributes from the refund response to the Eway\R…

### DIFF
--- a/src/Rapid/Model/RefundDetails.php
+++ b/src/Rapid/Model/RefundDetails.php
@@ -21,5 +21,17 @@ class RefundDetails extends AbstractModel
         'InvoiceDescription',
         'InvoiceReference',
         'CurrencyCode',
+        'AuthorisationID',
+    	'STAN',
+    	'ReceiptId',
+    	'Receipt',
+    	'ResponseCode',
+    	'ResponseText',
+    	'MerchantID',
+    	'TerminalID',
+    	'PosReference',
+    	'SettlementDate',
+    	'ReceiptGUID',
+    	'MposDeviceId'
     ];
 }


### PR DESCRIPTION
…apid\Model\RefundDetails $fillable array

The following attributes are now present in the production refund response and such have been added to the RefundDetails model:

'AuthorisationID', 'STAN', 'ReceiptId', 'Receipt', 'ResponseCode', 'ResponseText', 'MerchantID', 'TerminalID', 'PosReference', 'SettlementDate', 'ReceiptGUID', 'MposDeviceId'