### PR TITLE
Change Eway\Rapid\Service\Http::request() from private to protected

### DIFF
--- a/src/Rapid/Service/Http.php
+++ b/src/Rapid/Service/Http.php
@@ -349,7 +349,7 @@ class Http implements HttpServiceContract
      *
      * @return ResponseInterface
      */
-    private function request($method, $uri, $data = [])
+    protected function request($method, $uri, $data = [])
     {
         $uri = $this->getUri($uri);
 


### PR DESCRIPTION
This allows people to simply extend this class and override the request() method to swap out curl for something else.