### PR TITLE
PHP5.6 support

### DIFF
--- a/src/Rapid/Client.php
+++ b/src/Rapid/Client.php
@@ -444,7 +444,7 @@ class Client implements ClientContract
      */
     private function doCreateCustomer($apiMethod, $customer)
     {
-        $paymentInstrument = $customer['PaymentInstrument'] ?? null;
+        $paymentInstrument = isset($customer['PaymentInstrument']) ? $customer['PaymentInstrument'] : null;
 
         /** @var Customer $customer */
         $customer = ClassValidator::getInstance('Eway\Rapid\Model\Customer', $customer);


### PR DESCRIPTION
"null coalescing operator" breaks PHP 5.x support
Re-instated as standard isset()