### PR TITLE
PHP deprecation warning fixed for dynamic property

### DIFF
--- a/src/Rapid/Service/Http/Response.php
+++ b/src/Rapid/Service/Http/Response.php
@@ -15,6 +15,12 @@ class Response implements ResponseInterface
     /** @var int */
     private $statusCode = 200;
 
+    /** var string */
+    private $body;
+
+    /** var string */
+    private $error;
+
     /**
      * @param int    $status Status code for the response, if any.
      * @param string $body   Response body.


### PR DESCRIPTION
Deprecation waring of non defined member variables found for PHP8.2
Assign as private member variables following format of status